### PR TITLE
feat(server): log server and New Zealand time for race meeting fetch

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,16 +20,18 @@ connect()
     // Invoke fetchAndStoreRaceMeetings immediately
     raceMeetingService
       .fetchAndStoreRaceMeetings()
-      .then(() =>
+      .then(() => {
+        const ServerTime = new Date().toLocaleString()
+        const nzTime = new Date().toLocaleString('en-NZ', {
+          timeZone: 'Pacific/Auckland',
+        })
         console.log(
           '\x1b[33m',
-          `${
-            new Date()
-              .toLocaleString('en-NZ', { timeZone: 'Pacific/Auckland' })
-              .split(',')[0]
-          } Initial race meetings fetch completed`
+          `Initial race meetings fetch completed at:
+        Server Time time: ${ServerTime}
+        New Zealand time: ${nzTime}`
         )
-      )
+      })
       .catch((error) =>
         console.error(
           '\x1b[31m',
@@ -46,14 +48,14 @@ connect()
         raceMeetingService
           .fetchAndStoreRaceMeetings()
           .then(() => {
-            const serverTime = new Date().toLocaleString()
+            const ServerTime = new Date().toLocaleString()
             const nzTime = new Date().toLocaleString('en-NZ', {
               timeZone: 'Pacific/Auckland',
             })
             console.log(
               '\x1b[33m',
               `Daily race meetings fetch completed at:
-        Server time: ${serverTime}
+        Server Time time: ${ServerTime}
         New Zealand time: ${nzTime}`
             )
           })


### PR DESCRIPTION
## Description

- Update the initial and daily race meeting fetch logging to include both the server time and the New Zealand time (Pacific/Auckland timezone)
- This provides easier debugging and visibility into when the fetch operations are completed

## Related Issue

## Checklist

- [x] You have tested the changes locally and they work as expected
- [x] You have added appropriate documentation or updated existing documentation
- [x] You have followed the coding style and guidelines of the project
- [x] You have added/updated tests to ensure the changes are properly covered
- [x] You have reviewed the changes and ensured they meet the project's quality standards

## Screenshots (if applicable)

## Additional Notes
