### PR TITLE
chore: update MONGODB_URI in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - PORT=5020
       - NZ_TAB_URL=https://json.tab.co.nz/schedule/
-      - MONGODB_URI=mongodb://host.docker.internal:27017/raceday2
+      - MONGODB_URI=mongodb://localhost:27017/raceday2
 
     networks:
       - app-network


### PR DESCRIPTION
## Description

Update the MONGODB_URI environment variable in the docker-compose.yml file to use the localhost address instead of the host.docker.internal address.

## Related Issue

## Checklist

- [x] You have tested the changes locally and they work as expected
- [x ] You have added appropriate documentation or updated existing documentation
- [x] You have followed the coding style and guidelines of the project
- [x ] You have added/updated tests to ensure the changes are properly covered
- [x] You have reviewed the changes and ensured they meet the project's quality standards

## Screenshots (if applicable)

## Additional Notes
