### PR TITLE
chore: update MONGODB_URI in docker-compose and Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     environment:
       - PORT=5020
       - NZ_TAB_URL=https://json.tab.co.nz/schedule/
-      - MONGODB_URI=mongodb://localhost:27017/raceday2
-
+      - MONGODB_URI=mongodb://mongodb:27017/raceday2
     networks:
       - app-network
 
@@ -20,13 +19,11 @@ services:
     environment:
       - API_URL=http://server:5020
       - NEXT_PUBLIC_API_URL=http://localhost:5020
-
+    depends_on:
+      - server
     networks:
       - app-network
 
-    depends_on:
-      - server
-
 networks:
   app-network:
-    driver: bridge
+    external: true

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Set environment variables
 ENV NZ_TAB_URL=https://json.tab.co.nz/schedule/
-ENV MONGODB_URI=mongodb://10.1.1.95:27017/raceday2
+ENV MONGODB_URI=mongodb://mongodb:27017/raceday2
 
 # Copy package.json and bun.lockb (if you have one)
 COPY package.json bun.lockb* ./


### PR DESCRIPTION
## Description

Update the MONGODB_URI environment variable in the docker-compose.yml and Dockerfile to use the `mongodb` service name instead of `localhost` or IP address.

## Related Issue

## Checklist

- [x] You have tested the changes locally and they work as expected
- [x ] You have added appropriate documentation or updated existing documentation
- [x] You have followed the coding style and guidelines of the project
- [x ] You have added/updated tests to ensure the changes are properly covered
- [x] You have reviewed the changes and ensured they meet the project's quality standards

## Screenshots (if applicable)

## Additional Notes
